### PR TITLE
Enable preset boot

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -92,8 +92,8 @@ android {
         applicationId 'dev.mrkprdo.kolori'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 16
-        versionName "0.2.10"
+        versionCode 17
+        versionName "0.2.11"
     }
     signingConfigs {
         debug {

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Kolori",
     "slug": "Kolori",
-    "version": "0.2.10",
+    "version": "0.2.11",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
@@ -33,8 +33,8 @@
       "package": "dev.mrkprdo.kolori",
       "usesCleartextTraffic": true,
       "networkSecurityConfig": "@xml/network_security_config",
-      "versionCode": 16,
-      "versionName": "0.2.10"
+      "versionCode": 17,
+      "versionName": "0.2.11"
     },
     "web": {
       "favicon": "./assets/kolori.png"

--- a/ios/Kolori.xcodeproj/project.pbxproj
+++ b/ios/Kolori.xcodeproj/project.pbxproj
@@ -351,7 +351,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.2.10;
+				MARKETING_VERSION = 0.2.11;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -389,7 +389,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.2.10;
+				MARKETING_VERSION = 0.2.11;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/ios/Kolori/Info.plist
+++ b/ios/Kolori/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.2.10</string>
+    <string>0.2.11</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>
@@ -32,7 +32,7 @@
       </dict>
     </array>
     <key>CFBundleVersion</key>
-    <string>2</string>
+    <string>1</string>
     <key>LSMinimumSystemVersion</key>
     <string>12.0</string>
     <key>LSRequiresIPhoneOS</key>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kolori",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kolori",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "dependencies": {
         "@expo-google-fonts/montserrat": "^0.4.2",
         "@expo/cli": "^0.24.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kolori",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "main": "index.ts",
   "scripts": {
     "start": "expo start",

--- a/src/components/FloatingModal.tsx
+++ b/src/components/FloatingModal.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useEffect } from 'react';
 import { View, Text, Modal, TouchableOpacity, StyleSheet, SafeAreaView, Platform, Keyboard } from 'react-native';
 import { GestureDetector, Gesture, GestureHandlerRootView } from 'react-native-gesture-handler';
+import { Ionicons } from '@expo/vector-icons';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
@@ -157,8 +158,17 @@ export default function FloatingModal({
                   <View style={[styles.handle, { backgroundColor: isDark ? '#4b5563' : '#d1d5db' }]} />
                 </View>
 
-                {/* Title */}
-                <Text style={[styles.title, { color: textColor }]}>{title}</Text>
+                {/* Title and Close Button */}
+                <View style={styles.titleRow}>
+                  <Text style={[styles.title, { color: textColor }]}>{title}</Text>
+                  <TouchableOpacity
+                    onPress={onClose}
+                    style={styles.closeButton}
+                    hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+                  >
+                    <Ionicons name="close" size={24} color={textColor} />
+                  </TouchableOpacity>
+                </View>
               </View>
             </GestureDetector>
 
@@ -235,10 +245,23 @@ const styles = StyleSheet.create({
     height: 3,
     borderRadius: 2,
   },
+  titleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 16,
+    position: 'relative',
+  },
   title: {
     fontSize: 18,
     fontWeight: '600',
     textAlign: 'center',
+    flex: 1,
+  },
+  closeButton: {
+    position: 'absolute',
+    right: 16,
+    padding: 4,
   },
   keyboardAvoidingView: {
     flex: 1,

--- a/src/components/KoloriApp.tsx
+++ b/src/components/KoloriApp.tsx
@@ -142,7 +142,7 @@ function KoloriApp({
     }
   }, [activeDevice?.id, activeDevice?.isConnected, onDeviceUpdate]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const { liveLedData, setDevice: setWledContextDevice, toggleLiveView, liveViewEnabled } = useWledDevice();
+  const { liveLedData, setDevice: setWledContextDevice, toggleLiveView, liveViewEnabled, state: wledState } = useWledDevice();
 
   // Sync active device with WebSocket context
   useEffect(() => {
@@ -150,6 +150,17 @@ function KoloriApp({
       setWledContextDevice(activeDevice);
     }
   }, [activeDevice, setWledContextDevice]);
+
+  // Sync WebSocket active preset back to device cache
+  useEffect(() => {
+    if (activeDevice?.id && wledState.activePreset !== null && wledState.activePreset !== undefined) {
+      // Only update if the active preset from WebSocket differs from device cache
+      if (activeDevice.activePreset !== wledState.activePreset) {
+        logger.log(`🔄 Syncing active preset from WebSocket to device cache: ${wledState.activePreset}`);
+        onDeviceUpdate(activeDevice.id, { activePreset: wledState.activePreset });
+      }
+    }
+  }, [activeDevice?.id, activeDevice?.activePreset, wledState.activePreset, onDeviceUpdate]);
 
   const deviceMonitor = useDeviceMonitor({
     devices,

--- a/src/components/PresetGrid.tsx
+++ b/src/components/PresetGrid.tsx
@@ -67,6 +67,7 @@ import CustomEffectsModal from "./CustomEffectsModal";
 import SchedulerModal from "./SchedulerModal";
 import PlaylistCreationModal from "./PlaylistCreationModal";
 import DeviceManagementModal from "./DeviceManagementModal";
+import PresetOptionsModal from "./PresetOptionsModal";
 import { WLEDEffectData, getEffectByName } from "../data/wledEffects";
 import { WLED_PALETTES_DEF } from "../constants/palettes";
 import DeviceSelection from "./PresetGrid/DeviceSelection";
@@ -183,8 +184,51 @@ export default function PresetGrid({
     toggleLiveView: toggleLiveViewWS,
     isConnected: wsConnected,
     liveViewEnabled: liveViewEnabledWS,
-    liveLedData: liveLedDataWS
+    liveLedData: liveLedDataWS,
+    sendCommand: sendWledCommand
   } = useWledDevice();
+
+  // State to hold boot preset ID fetched via HTTP
+  const [fetchedBootPresetId, setFetchedBootPresetId] = useState<number | null>(null);
+
+  // Use boot preset ID from HTTP fetch (bootps is not in WebSocket state, only in /json/cfg)
+  const bootPresetIdFromDevice = fetchedBootPresetId ?? null;
+
+  // Debug: Log the boot preset ID
+  useEffect(() => {
+    logger.log('🔍 Boot Preset ID from device config:', fetchedBootPresetId);
+    logger.log('🔍 Final Boot Preset ID:', bootPresetIdFromDevice);
+  }, [fetchedBootPresetId, bootPresetIdFromDevice]);
+
+  // Fetch boot preset ID from device config when connected
+  useEffect(() => {
+    const fetchBootPresetId = async () => {
+      if (!activeDevice?.ip || !activeDevice?.isConnected) return;
+
+      try {
+        // Fetch from /json/cfg to get the boot preset configuration
+        const response = await fetch(`http://${activeDevice.ip}/json/cfg`);
+        if (response.ok) {
+          const config = await response.json();
+          logger.log('🔍 Fetched device config via HTTP');
+          logger.log('🔍 Boot preset ID in config:', config?.def?.ps);
+
+          if (config?.def?.ps !== undefined) {
+            const bootPs = config.def.ps;
+            setFetchedBootPresetId(bootPs);
+            // Also update local storage
+            await storage.saveToStorage(STORAGE_KEYS.BOOT_PRESET_ID, bootPs);
+            setBootPresetId(bootPs);
+            logger.log('✅ Boot preset ID loaded from device:', bootPs);
+          }
+        }
+      } catch (error) {
+        logger.error('Failed to fetch boot preset ID:', error);
+      }
+    };
+
+    fetchBootPresetId();
+  }, [activeDevice?.ip, activeDevice?.isConnected]);
 
   const [currentPage, setCurrentPage] = useState(0); // 0 = Presets, 1 = Audio Reactive
   const [isAudioReactiveActive, setIsAudioReactiveActive] = useState(false);
@@ -197,6 +241,10 @@ export default function PresetGrid({
   const [showPlaylistCreationModal, setShowPlaylistCreationModal] =
     useState(false);
   const [showSchedulerModal, setShowSchedulerModal] = useState(false);
+  const [showPresetOptionsModal, setShowPresetOptionsModal] = useState(false);
+  const [selectedPresetForOptions, setSelectedPresetForOptions] = useState<any>(null);
+  const [isSelectedPresetDeletable, setIsSelectedPresetDeletable] = useState(true);
+  const [bootPresetId, setBootPresetId] = useState<string | number | null>(null);
   const [showFabOptions, setShowFabOptions] = useState(false);
   const [showCreateNewOptions, setShowCreateNewOptions] = useState(false);
   const [showDeviceDropdown, setShowDeviceDropdown] = useState(false);
@@ -821,6 +869,25 @@ export default function PresetGrid({
         logger.log(`💡 Brightness updated from refresh: ${newBrightness}`);
       }
 
+      // Also fetch boot preset ID from device config
+      if (currentDevice?.ip) {
+        try {
+          const response = await fetch(`http://${currentDevice.ip}/json/cfg`);
+          if (response.ok) {
+            const config = await response.json();
+            if (config?.def?.ps !== undefined) {
+              const bootPs = config.def.ps;
+              setFetchedBootPresetId(bootPs);
+              await storage.saveToStorage(STORAGE_KEYS.BOOT_PRESET_ID, bootPs);
+              setBootPresetId(bootPs);
+              logger.log('✅ Boot preset ID refreshed from device:', bootPs);
+            }
+          }
+        } catch (bootError) {
+          logger.error('Failed to fetch boot preset during refresh:', bootError);
+        }
+      }
+
     } catch (error) {
       logger.error("Failed to refresh presets:", error);
     } finally {
@@ -832,6 +899,272 @@ export default function PresetGrid({
     sliderBrightness,
   ]);
 
+  // Load boot preset from storage
+  useEffect(() => {
+    const loadBootPreset = async () => {
+      try {
+        const saved = await storage.loadFromStorage(STORAGE_KEYS.BOOT_PRESET_ID, null);
+        if (saved) {
+          setBootPresetId(saved);
+        }
+      } catch (error) {
+        logger.error('Failed to load boot preset:', error);
+      }
+    };
+    loadBootPreset();
+  }, []);
+
+  // Handle preset long press to show options
+  const handlePresetLongPress = useCallback((preset: any, isDeletable: boolean = true) => {
+    setSelectedPresetForOptions(preset);
+    setIsSelectedPresetDeletable(isDeletable);
+    setShowPresetOptionsModal(true);
+  }, []);
+
+  // Handle enabling/disabling preset at boot
+  const handleEnableAtBoot = useCallback(async () => {
+    if (!selectedPresetForOptions) return;
+
+    const presetId = selectedPresetForOptions.presetId || selectedPresetForOptions.id;
+    const presetName = selectedPresetForOptions.name;
+
+    // Check if this is a playlist (has items array) or a regular preset
+    const isPlaylist = Array.isArray(selectedPresetForOptions.items);
+
+    // Debug: Log the preset details
+    logger.log('🔍 Selected preset for boot:', JSON.stringify(selectedPresetForOptions, null, 2));
+    logger.log('🔍 Detected as playlist?', isPlaylist);
+    logger.log('🔍 Items array?', Array.isArray(selectedPresetForOptions.items));
+    logger.log('🔍 Items:', selectedPresetForOptions.items);
+
+    // If already boot preset, disable it
+    if (bootPresetId === presetId) {
+      Alert.alert(
+        'Disable Boot Preset',
+        `Disable "${presetName}" from loading at boot?`,
+        [
+          { text: 'Cancel', style: 'cancel' },
+          {
+            text: 'Disable',
+            style: 'destructive',
+            onPress: async () => {
+              try {
+                // Disable boot preset by setting it to 0 in the device config
+                if (activeDevice?.ip) {
+                  const command = { def: { ps: 0 } };
+                  logger.log('📡 Disabling boot preset via /json/cfg');
+
+                  try {
+                    const response = await fetch(`http://${activeDevice.ip}/json/cfg`, {
+                      method: 'POST',
+                      headers: {
+                        'Content-Type': 'application/json',
+                      },
+                      body: JSON.stringify(command),
+                    });
+
+                    if (response.ok) {
+                      logger.log('✅ Boot preset disabled on device');
+                    } else {
+                      logger.error(`Failed to disable boot preset: HTTP ${response.status}`);
+                    }
+                  } catch (httpError) {
+                    logger.error('Failed to send disable command:', httpError);
+                  }
+                }
+
+                await storage.removeFromStorage(STORAGE_KEYS.BOOT_PRESET_ID);
+                setBootPresetId(null);
+                setFetchedBootPresetId(0); // Set to 0 to indicate no boot preset
+                logger.log('🔴 Boot preset disabled');
+
+                if (Platform.OS === 'android') {
+                  ToastAndroid.show('Boot preset disabled', ToastAndroid.SHORT);
+                }
+              } catch (error) {
+                logger.error('Failed to disable boot preset:', error);
+              }
+            },
+          },
+        ]
+      );
+      return;
+    }
+
+    // If another preset is already set as boot preset, confirm replacement
+    if (bootPresetId && bootPresetId !== presetId) {
+      Alert.alert(
+        'Replace Boot Preset',
+        `Set "${presetName}" as boot preset?\n\nOnly one preset can load at boot. This will replace the current boot preset.`,
+        [
+          { text: 'Cancel', style: 'cancel' },
+          {
+            text: 'Set as Boot Preset',
+            onPress: async () => {
+              try {
+                if (!activeDevice) {
+                  Alert.alert('Error', 'No active device');
+                  return;
+                }
+
+                // Use /json/cfg endpoint to configure boot preset
+                // The boot preset is stored in cfg.json under "def" -> "ps"
+                const command = { def: { ps: presetId } };
+
+                logger.log(`📡 Setting preset ${presetId} as boot preset via /json/cfg`);
+                logger.log(`📡 Request body:`, JSON.stringify(command));
+
+                // Send to /json/cfg to modify the boot preset configuration
+                try {
+                  const response = await fetch(`http://${activeDevice.ip}/json/cfg`, {
+                    method: 'POST',
+                    headers: {
+                      'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify(command),
+                  });
+
+                  if (!response.ok) {
+                    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+                  }
+
+                  const result = await response.json();
+                  logger.log(`✅ HTTP POST response:`, JSON.stringify(result));
+                } catch (httpError) {
+                  logger.error('Failed to set boot preset via /json/cfg:', httpError);
+                  throw httpError;
+                }
+
+                await storage.saveToStorage(STORAGE_KEYS.BOOT_PRESET_ID, presetId);
+                setBootPresetId(presetId);
+                setFetchedBootPresetId(presetId); // Update fetched state so star shows immediately
+                logger.log(`🟢 Boot preset set to: ${presetId}`);
+
+                if (Platform.OS === 'android') {
+                  ToastAndroid.show(`"${presetName}" will load at boot`, ToastAndroid.SHORT);
+                } else {
+                  Alert.alert('Boot Preset Set', `"${presetName}" will load when device powers on\n\nPreset ID: ${presetId}`);
+                }
+              } catch (error) {
+                logger.error('Failed to save boot preset:', error);
+                const errorMsg = error instanceof Error ? error.message : 'Unknown error';
+                Alert.alert('Error', `Failed to set boot preset: ${errorMsg}`);
+              }
+            },
+          },
+        ]
+      );
+    } else {
+      // No existing boot preset, just set it
+      try {
+        if (!activeDevice) {
+          Alert.alert('Error', 'No active device');
+          return;
+        }
+
+        // Use /json/cfg endpoint to configure boot preset
+        // The boot preset is stored in cfg.json under "def" -> "ps"
+        const command = { def: { ps: presetId } };
+
+        logger.log(`📡 Setting preset ${presetId} as boot preset via /json/cfg`);
+        logger.log(`📡 Request body:`, JSON.stringify(command));
+
+        // Send to /json/cfg to modify the boot preset configuration
+        try {
+          const response = await fetch(`http://${activeDevice.ip}/json/cfg`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(command),
+          });
+
+          if (!response.ok) {
+            throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+          }
+
+          const result = await response.json();
+          logger.log(`✅ HTTP POST response:`, JSON.stringify(result));
+        } catch (httpError) {
+          logger.error('Failed to set boot preset via /json/cfg:', httpError);
+          throw httpError;
+        }
+
+        await storage.saveToStorage(STORAGE_KEYS.BOOT_PRESET_ID, presetId);
+        setBootPresetId(presetId);
+        setFetchedBootPresetId(presetId); // Update fetched state so star shows immediately
+        logger.log(`🟢 Boot preset set to: ${presetId}`);
+
+        if (Platform.OS === 'android') {
+          ToastAndroid.show(`"${presetName}" will load at boot`, ToastAndroid.SHORT);
+        } else {
+          Alert.alert('Boot Preset Set', `"${presetName}" will load when device powers on\n\nPreset ID: ${presetId}`);
+        }
+      } catch (error) {
+        logger.error('Failed to save boot preset:', error);
+        const errorMsg = error instanceof Error ? error.message : 'Unknown error';
+        Alert.alert('Error', `Failed to set boot preset: ${errorMsg}`);
+      }
+    }
+  }, [selectedPresetForOptions, bootPresetId, activeDevice]);
+
+  // Handle deleting preset
+  const handleDeletePreset = useCallback(async () => {
+    if (!selectedPresetForOptions || !activeDevice) return;
+
+    const presetName = selectedPresetForOptions.name;
+    const presetId = selectedPresetForOptions.presetId || selectedPresetForOptions.id;
+
+    Alert.alert(
+      'Delete Preset',
+      `Are you sure you want to delete "${presetName}"?`,
+      [
+        {
+          text: 'Cancel',
+          style: 'cancel',
+        },
+        {
+          text: 'Delete',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              logger.log(`🗑️ Deleting preset ${presetId} from device ${activeDevice.ip}`);
+
+              const result = await deleteWledPreset(
+                activeDevice.ip,
+                presetId,
+                activeDevice.protocol || 'http'
+              );
+
+              if (result.success) {
+                logger.log(`✅ Successfully deleted preset ${presetId}`);
+
+                // Refresh presets after deletion
+                if (onRefreshPresets) {
+                  await onRefreshPresets();
+                }
+
+                // Show success message
+                if (Platform.OS === 'android') {
+                  ToastAndroid.show(`Deleted "${presetName}"`, ToastAndroid.SHORT);
+                } else {
+                  Alert.alert('Success', `Deleted "${presetName}"`);
+                }
+              } else {
+                throw new Error(result.error || 'Failed to delete preset');
+              }
+            } catch (error) {
+              logger.error(`Failed to delete preset ${presetId}:`, error);
+              Alert.alert(
+                'Error',
+                `Failed to delete preset: ${error instanceof Error ? error.message : 'Unknown error'}`
+              );
+            }
+          },
+        },
+      ]
+    );
+  }, [selectedPresetForOptions, activeDevice, onRefreshPresets]);
 
   // Animation coordination (non-blocking)
   const fabAnimationInProgress = useRef(false);
@@ -1642,6 +1975,7 @@ export default function PresetGrid({
           <SeasonalPresetsSection
             seasonalPresets={seasonalPresets}
             activePreset={activePreset}
+            bootPresetId={bootPresetIdFromDevice}
             isCollapsed={isSeasonalCollapsed}
             isBlocked={!activeDevice?.isConnected || isAudioReactiveActive}
             blockReason={!activeDevice?.isConnected ? 'offline' : 'audioReactive'}
@@ -1652,6 +1986,7 @@ export default function PresetGrid({
             subtextColor={subtextColor}
             onToggleCollapse={() => setIsSeasonalCollapsed(!isSeasonalCollapsed)}
             onPresetSelect={onPresetSelect}
+            onLongPress={handlePresetLongPress}
             PresetCard={PresetCard}
           />
 
@@ -1659,6 +1994,7 @@ export default function PresetGrid({
           <CustomEffectsSection
             customEffects={memoizedCustomEffects}
             activePreset={activePreset}
+            bootPresetId={bootPresetIdFromDevice}
             activeDevice={activeDevice}
             isCollapsed={isCustomEffectsCollapsed}
             isBlocked={!activeDevice?.isConnected || isAudioReactiveActive}
@@ -1676,6 +2012,7 @@ export default function PresetGrid({
             subtextColor={subtextColor}
             onToggleCollapse={() => setIsCustomEffectsCollapsed(!isCustomEffectsCollapsed)}
             onPresetSelect={onPresetSelect}
+            onLongPress={handlePresetLongPress}
             onToggleSelection={toggleCardSelection}
             onGenerateRandom={generateRandomCustomEffect}
             PresetCard={MemoizedPresetCard}
@@ -1685,6 +2022,7 @@ export default function PresetGrid({
           <PlaylistsSection
             savedPlaylists={savedPlaylists}
             customEffectsCount={memoizedCustomEffects.length}
+            bootPresetId={bootPresetIdFromDevice}
             isCollapsed={isPlaylistsCollapsed}
             isBlocked={!activeDevice?.isConnected || isAudioReactiveActive}
             blockReason={!activeDevice?.isConnected ? 'offline' : 'audioReactive'}
@@ -1699,6 +2037,7 @@ export default function PresetGrid({
             subtextColor={subtextColor}
             onToggleCollapse={() => setIsPlaylistsCollapsed(!isPlaylistsCollapsed)}
             onPlaylistSelect={onPlaylistSelect}
+            onLongPress={handlePresetLongPress}
             onToggleSelection={toggleCardSelection}
           />
         </ScrollView>
@@ -2093,6 +2432,18 @@ export default function PresetGrid({
         setConfiguredSchedule={setConfiguredSchedule}
         schedulerEnabled={schedulerEnabled}
         setSchedulerEnabled={setSchedulerEnabled}
+      />
+
+      {/* Preset Options Modal */}
+      <PresetOptionsModal
+        visible={showPresetOptionsModal}
+        onClose={() => setShowPresetOptionsModal(false)}
+        isDark={isDark}
+        presetName={selectedPresetForOptions?.name || ''}
+        isBootPreset={bootPresetId === (selectedPresetForOptions?.presetId || selectedPresetForOptions?.id)}
+        showDelete={isSelectedPresetDeletable}
+        onEnableAtBoot={handleEnableAtBoot}
+        onDelete={handleDeletePreset}
       />
 
       {/* Deletion Progress Modal */}

--- a/src/components/PresetGrid/AnimatedPlaylistItem.tsx
+++ b/src/components/PresetGrid/AnimatedPlaylistItem.tsx
@@ -8,7 +8,9 @@ import { parseGradientString, extractPrimaryColor } from '../../utils/presetUtil
 interface AnimatedPlaylistItemProps {
   playlist: SavedPlaylist;
   index: number;
+  bootPresetId?: number | null;
   onPress: (id: number) => void;
+  onLongPress?: (preset: any, isDeletable?: boolean) => void;
   isDeleteMode?: boolean;
   isSelected?: boolean;
   onToggleSelection?: (id: string | number) => void;
@@ -19,7 +21,9 @@ const AnimatedPlaylistItem = React.memo(
   function AnimatedPlaylistItem({
     playlist,
     index,
+    bootPresetId,
     onPress,
+    onLongPress,
     isDeleteMode = false,
     isSelected = false,
     onToggleSelection,
@@ -45,6 +49,32 @@ const AnimatedPlaylistItem = React.memo(
         onPress(playlist.id);
       }
     }, [playlist.id, onPress, isDeleteMode, onToggleSelection]);
+
+    const handleLongPress = useCallback(() => {
+      if (!isDeleteMode && onLongPress) {
+        onLongPress(playlist, true); // Playlists are deletable
+      }
+    }, [playlist, onLongPress, isDeleteMode]);
+
+    // Check if this playlist is the boot preset
+    const isBootPreset = useMemo(
+      () => {
+        if (!bootPresetId) return false;
+
+        // Direct match by id
+        if (bootPresetId.toString() === playlist.id.toString()) {
+          return true;
+        }
+
+        // Match by presetId if available
+        if (playlist.presetId && bootPresetId.toString() === playlist.presetId.toString()) {
+          return true;
+        }
+
+        return false;
+      },
+      [bootPresetId, playlist.id, playlist.presetId]
+    );
 
     // Use LinearGradient colors for playlists if available
     const shouldUseGradient = playlist.gradient;
@@ -110,7 +140,7 @@ const AnimatedPlaylistItem = React.memo(
 
     return (
       <Animated.View style={containerStyle}>
-        <TouchableOpacity onPress={handlePress} style={styles.touchableArea}>
+        <TouchableOpacity onPress={handlePress} onLongPress={handleLongPress} style={styles.touchableArea}>
           <View style={cardStyle}>
             {shouldUseGradient && hasValidGradient && gradientColors && (
               <LinearGradient
@@ -133,6 +163,11 @@ const AnimatedPlaylistItem = React.memo(
                 {playlist.items?.length || 0} effects
               </Text>
             </View>
+            {isBootPreset && !isDeleteMode && (
+              <View style={styles.bootIndicator}>
+                <Ionicons name="star" size={16} color="#FFD700" />
+              </View>
+            )}
             {playlist.isActive && !isDeleteMode && (
               <View style={styles.activeIndicator}>
                 <Ionicons name="checkmark-circle" size={20} color="#ffffff" />
@@ -154,9 +189,11 @@ const AnimatedPlaylistItem = React.memo(
     return (
       prevProps.playlist.id === nextProps.playlist.id &&
       prevProps.playlist.name === nextProps.playlist.name &&
+      prevProps.playlist.presetId === nextProps.playlist.presetId &&
       prevProps.playlist.isActive === nextProps.playlist.isActive &&
       prevProps.playlist.items?.length === nextProps.playlist.items?.length &&
       prevProps.index === nextProps.index &&
+      prevProps.bootPresetId === nextProps.bootPresetId &&
       prevProps.isDeleteMode === nextProps.isDeleteMode &&
       prevProps.isSelected === nextProps.isSelected
     );
@@ -223,6 +260,11 @@ const styles = StyleSheet.create({
     position: 'absolute',
     top: 4,
     right: 4,
+  },
+  bootIndicator: {
+    position: 'absolute',
+    top: 4,
+    left: 4,
   },
   deleteOverlay: {
     position: 'absolute',

--- a/src/components/PresetGrid/CustomEffectsSection.tsx
+++ b/src/components/PresetGrid/CustomEffectsSection.tsx
@@ -7,6 +7,7 @@ import { sharedStyles } from './styles';
 interface CustomEffectsSectionProps {
   customEffects: CustomEffect[];
   activePreset: string | number | null;
+  bootPresetId: number | null;
   activeDevice: { isConnected?: boolean } | undefined;
   isCollapsed: boolean;
   isBlocked?: boolean;
@@ -24,6 +25,7 @@ interface CustomEffectsSectionProps {
   subtextColor: string;
   onToggleCollapse: () => void;
   onPresetSelect: (id: string | number) => void;
+  onLongPress?: (preset: any, isDeletable?: boolean) => void;
   onToggleSelection: (id: string | number) => void;
   onGenerateRandom: () => void;
   PresetCard: React.ComponentType<any>;
@@ -32,6 +34,7 @@ interface CustomEffectsSectionProps {
 const CustomEffectsSection: React.FC<CustomEffectsSectionProps> = ({
   customEffects,
   activePreset,
+  bootPresetId,
   activeDevice,
   isCollapsed,
   isBlocked = false,
@@ -49,6 +52,7 @@ const CustomEffectsSection: React.FC<CustomEffectsSectionProps> = ({
   subtextColor,
   onToggleCollapse,
   onPresetSelect,
+  onLongPress,
   onToggleSelection,
   onGenerateRandom,
   PresetCard,
@@ -184,7 +188,9 @@ const CustomEffectsSection: React.FC<CustomEffectsSectionProps> = ({
                       preset={preset}
                       index={index}
                       activePreset={activePreset}
+                      bootPresetId={bootPresetId}
                       onPresetSelect={onPresetSelect}
+                      onLongPress={onLongPress}
                       isDark={isDark}
                       isDeleteMode={isDeleteMode}
                       isSelected={selectedForDelete.has(preset.id)}

--- a/src/components/PresetGrid/DeviceSelection.tsx
+++ b/src/components/PresetGrid/DeviceSelection.tsx
@@ -105,12 +105,22 @@ const DeviceSelection: React.FC<DeviceSelectionProps> = ({
                 },
               ]}
             />
-            <Text
-              style={[styles.dropdownText, { color: textColor }]}
-              numberOfLines={1}
-            >
-              {activeDevice?.name || 'No Device'}
-            </Text>
+            <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+              <Text
+                style={[styles.dropdownText, { color: textColor, marginLeft: 0, flex: 0 }]}
+                numberOfLines={1}
+              >
+                {activeDevice?.name || 'No Device'}
+              </Text>
+              {activeDevice?.ip && (
+                <Text
+                  style={[styles.dropdownText, { color: subtextColor, fontSize: 12, marginLeft: 0, flex: 0, marginTop: 2 }]}
+                  numberOfLines={1}
+                >
+                  {activeDevice.ip}
+                </Text>
+              )}
+            </View>
             <Ionicons
               name={showDeviceDropdown ? 'chevron-up' : 'chevron-down'}
               size={16}

--- a/src/components/PresetGrid/MemoizedPresetCard.tsx
+++ b/src/components/PresetGrid/MemoizedPresetCard.tsx
@@ -6,7 +6,9 @@ interface MemoizedPresetCardProps {
   preset: any;
   index: number;
   activePreset: string | number | null;
+  bootPresetId?: number | null;
   onPresetSelect: (id: string | number) => void;
+  onLongPress?: (preset: any, isDeletable?: boolean) => void;
   isDark: boolean;
   isDeleteMode: boolean;
   isSelected: boolean;
@@ -20,7 +22,9 @@ const MemoizedPresetCard = React.memo(
     preset,
     index,
     activePreset,
+    bootPresetId,
     onPresetSelect,
+    onLongPress,
     isDark,
     isDeleteMode,
     isSelected,
@@ -55,16 +59,51 @@ const MemoizedPresetCard = React.memo(
       [activePreset, preset.id, preset.presetId]
     );
 
+    const isBootPreset = useMemo(
+      () => {
+        if (!bootPresetId) return false;
+
+        // Direct match by id
+        if (bootPresetId.toString() === preset.id.toString()) {
+          return true;
+        }
+
+        // Match by presetId if available
+        if (preset.presetId && bootPresetId.toString() === preset.presetId.toString()) {
+          return true;
+        }
+
+        // For WLED presets with "wled_X" format, match numeric part
+        if (typeof preset.id === 'string' && preset.id.startsWith('wled_')) {
+          const numericId = parseInt(preset.id.replace('wled_', ''));
+          if (bootPresetId.toString() === numericId.toString()) {
+            return true;
+          }
+        }
+
+        return false;
+      },
+      [bootPresetId, preset.id, preset.presetId]
+    );
+
     const handleClick = useCallback(() => {
       onPresetSelect(preset.id);
     }, [onPresetSelect, preset.id]);
+
+    const handleLongPress = useCallback(() => {
+      if (onLongPress) {
+        onLongPress(preset, true); // Custom effects are deletable
+      }
+    }, [onLongPress, preset]);
 
     return (
       <PresetCard
         preset={preset}
         animationDelay={index * 50}
         isActive={isActive}
+        isBootPreset={isBootPreset}
         onClick={handleClick}
+        onLongPress={handleLongPress}
         showIcon={showIcon}
         isDark={isDark}
         isDeleteMode={isDeleteMode}
@@ -87,9 +126,25 @@ const MemoizedPresetCard = React.memo(
       return false;
     };
 
+    // Helper to check if this card is boot preset
+    const isCardBootPreset = (bootPresetId: number | null | undefined, preset: any) => {
+      if (!bootPresetId) return false;
+      if (bootPresetId.toString() === preset.id.toString()) return true;
+      if (preset.presetId && bootPresetId.toString() === preset.presetId.toString()) return true;
+      if (typeof preset.id === 'string' && preset.id.startsWith('wled_')) {
+        const numericId = parseInt(preset.id.replace('wled_', ''));
+        if (bootPresetId.toString() === numericId.toString()) return true;
+      }
+      return false;
+    };
+
     // Only check if this card's active state changed, not all activePreset changes
     const wasActive = isCardActive(prevProps.activePreset, prevProps.preset);
     const isActive = isCardActive(nextProps.activePreset, nextProps.preset);
+
+    // Check if boot preset state changed for this card
+    const wasBootPreset = isCardBootPreset(prevProps.bootPresetId, prevProps.preset);
+    const isBootPreset = isCardBootPreset(nextProps.bootPresetId, nextProps.preset);
 
     return (
       prevProps.preset.id === nextProps.preset.id &&
@@ -98,6 +153,7 @@ const MemoizedPresetCard = React.memo(
       prevProps.preset.effectName === nextProps.preset.effectName &&
       prevProps.index === nextProps.index &&
       wasActive === isActive && // Only re-render if THIS card's active state changed
+      wasBootPreset === isBootPreset && // Only re-render if THIS card's boot preset state changed
       prevProps.isDark === nextProps.isDark &&
       prevProps.isDeleteMode === nextProps.isDeleteMode &&
       prevProps.isSelected === nextProps.isSelected &&

--- a/src/components/PresetGrid/PlaylistsSection.tsx
+++ b/src/components/PresetGrid/PlaylistsSection.tsx
@@ -8,6 +8,7 @@ import AnimatedPlaylistItem from './AnimatedPlaylistItem';
 interface PlaylistsSectionProps {
   savedPlaylists: SavedPlaylist[];
   customEffectsCount: number;
+  bootPresetId: number | null;
   isCollapsed: boolean;
   isBlocked?: boolean;
   blockReason?: 'offline' | 'audioReactive';
@@ -22,12 +23,14 @@ interface PlaylistsSectionProps {
   subtextColor: string;
   onToggleCollapse: () => void;
   onPlaylistSelect: (id: number) => void;
+  onLongPress?: (preset: any, isDeletable?: boolean) => void;
   onToggleSelection: (id: string | number) => void;
 }
 
 const PlaylistsSection: React.FC<PlaylistsSectionProps> = ({
   savedPlaylists,
   customEffectsCount,
+  bootPresetId,
   isCollapsed,
   isBlocked = false,
   blockReason = 'offline',
@@ -42,6 +45,7 @@ const PlaylistsSection: React.FC<PlaylistsSectionProps> = ({
   subtextColor,
   onToggleCollapse,
   onPlaylistSelect,
+  onLongPress,
   onToggleSelection,
 }) => {
   return (
@@ -88,7 +92,9 @@ const PlaylistsSection: React.FC<PlaylistsSectionProps> = ({
                   key={`playlist-${playlist.id}-${index}`}
                   playlist={playlist}
                   index={index}
+                  bootPresetId={bootPresetId}
                   onPress={onPlaylistSelect}
+                  onLongPress={onLongPress}
                   isDeleteMode={isDeleteMode}
                   isSelected={selectedForDelete.has(playlist.id)}
                   onToggleSelection={onToggleSelection}

--- a/src/components/PresetGrid/PresetCard.tsx
+++ b/src/components/PresetGrid/PresetCard.tsx
@@ -8,7 +8,9 @@ interface PresetCardProps {
   preset: any;
   animationDelay?: number;
   isActive: boolean;
+  isBootPreset?: boolean;
   onClick: (id: string | number) => void;
+  onLongPress?: (preset: any) => void;
   showIcon?: boolean;
   isDark?: boolean;
   isDeleteMode?: boolean;
@@ -22,7 +24,9 @@ const PresetCard = React.memo(
     preset,
     animationDelay = 0,
     isActive,
+    isBootPreset = false,
     onClick,
+    onLongPress,
     showIcon = false,
     isDark = false,
     isDeleteMode = false,
@@ -76,6 +80,12 @@ const PresetCard = React.memo(
         onClick(preset.id);
       }
     }, [preset.id, onClick, isDeleteMode, onToggleSelection]);
+
+    const handleCardLongPress = useCallback(() => {
+      if (!isDeleteMode && onLongPress) {
+        onLongPress(preset);
+      }
+    }, [preset, onLongPress, isDeleteMode]);
 
     const animatedTransformStyle = useMemo(
       () => ({
@@ -142,6 +152,7 @@ const PresetCard = React.memo(
       <Animated.View style={[animatedTransformStyle, cardItemStyle]}>
         <TouchableOpacity
           onPress={handleCardPress}
+          onLongPress={handleCardLongPress}
           style={styles.touchableArea}
         >
           <View style={cardViewStyle}>
@@ -169,6 +180,11 @@ const PresetCard = React.memo(
                 <Text style={styles.cardSubtitle}>{preset.effectName}</Text>
               )}
             </View>
+            {isBootPreset && !isDeleteMode && (
+              <View style={styles.bootIndicator}>
+                <Ionicons name="star" size={16} color="#FFD700" />
+              </View>
+            )}
             {isActive && !isDeleteMode && (
               <View style={styles.activeIndicator}>
                 <Ionicons name="checkmark-circle" size={20} color="#ffffff" />
@@ -194,6 +210,7 @@ const PresetCard = React.memo(
       prevProps.preset.effectName === nextProps.preset.effectName &&
       prevProps.animationDelay === nextProps.animationDelay &&
       prevProps.isActive === nextProps.isActive &&
+      prevProps.isBootPreset === nextProps.isBootPreset &&
       prevProps.isDeleteMode === nextProps.isDeleteMode &&
       prevProps.isSelected === nextProps.isSelected &&
       prevProps.showIcon === nextProps.showIcon &&
@@ -260,6 +277,11 @@ const styles = StyleSheet.create({
     position: 'absolute',
     top: 4,
     right: 4,
+  },
+  bootIndicator: {
+    position: 'absolute',
+    top: 4,
+    left: 4,
   },
   deleteOverlay: {
     position: 'absolute',

--- a/src/components/PresetGrid/SeasonalPresetsSection.tsx
+++ b/src/components/PresetGrid/SeasonalPresetsSection.tsx
@@ -8,6 +8,7 @@ import { sharedStyles } from './styles';
 interface SeasonalPresetsSectionProps {
   seasonalPresets: SeasonalPreset[];
   activePreset: string | number | null;
+  bootPresetId: number | null;
   isCollapsed: boolean;
   isBlocked?: boolean;
   blockReason?: 'offline' | 'audioReactive';
@@ -18,6 +19,7 @@ interface SeasonalPresetsSectionProps {
   subtextColor: string;
   onToggleCollapse: () => void;
   onPresetSelect: (id: string | number) => void;
+  onLongPress?: (preset: any, isDeletable?: boolean) => void;
   PresetCard: React.ComponentType<any>;
 }
 
@@ -26,14 +28,18 @@ const MemoizedSeasonalPresetCard = React.memo(
     preset,
     index,
     activePreset,
+    bootPresetId,
     onPresetSelect,
+    onLongPress,
     isDark,
     PresetCard,
   }: {
     preset: any;
     index: number;
     activePreset: string | number | null;
+    bootPresetId: number | null;
     onPresetSelect: (id: string | number) => void;
+    onLongPress?: (preset: any, isDeletable?: boolean) => void;
     isDark: boolean;
     PresetCard: React.ComponentType<any>;
   }) {
@@ -57,16 +63,29 @@ const MemoizedSeasonalPresetCard = React.memo(
       [activePreset, preset.presetId]
     );
 
+    const isBootPreset = useMemo(
+      () => bootPresetId?.toString() === preset.presetId.toString(),
+      [bootPresetId, preset.presetId]
+    );
+
     const handleClick = useCallback(() => {
       onPresetSelect(preset.presetId);
     }, [onPresetSelect, preset.presetId]);
+
+    const handleLongPress = useCallback(() => {
+      if (onLongPress) {
+        onLongPress(presetObj, false); // Seasonal presets are not deletable
+      }
+    }, [onLongPress, presetObj]);
 
     return (
       <PresetCard
         preset={presetObj}
         animationDelay={index * 50}
         isActive={isActive}
+        isBootPreset={isBootPreset}
         onClick={handleClick}
+        onLongPress={handleLongPress}
         showIcon={true}
         isDark={isDark}
         isDeleteMode={false}
@@ -81,6 +100,7 @@ const MemoizedSeasonalPresetCard = React.memo(
       prevProps.preset.icon === nextProps.preset.icon &&
       prevProps.index === nextProps.index &&
       prevProps.activePreset === nextProps.activePreset &&
+      prevProps.bootPresetId === nextProps.bootPresetId &&
       prevProps.isDark === nextProps.isDark
     );
   }
@@ -89,6 +109,7 @@ const MemoizedSeasonalPresetCard = React.memo(
 const SeasonalPresetsSection: React.FC<SeasonalPresetsSectionProps> = ({
   seasonalPresets,
   activePreset,
+  bootPresetId,
   isCollapsed,
   isBlocked = false,
   blockReason = 'offline',
@@ -99,6 +120,7 @@ const SeasonalPresetsSection: React.FC<SeasonalPresetsSectionProps> = ({
   subtextColor,
   onToggleCollapse,
   onPresetSelect,
+  onLongPress,
   PresetCard,
 }) => {
   return (
@@ -134,7 +156,9 @@ const SeasonalPresetsSection: React.FC<SeasonalPresetsSectionProps> = ({
                 preset={preset}
                 index={index}
                 activePreset={activePreset}
+                bootPresetId={bootPresetId}
                 onPresetSelect={onPresetSelect}
+                onLongPress={onLongPress}
                 isDark={isDark}
                 PresetCard={PresetCard}
               />

--- a/src/components/PresetOptionsModal.tsx
+++ b/src/components/PresetOptionsModal.tsx
@@ -1,0 +1,160 @@
+import React from 'react';
+import { View, Text, StyleSheet, Modal, TouchableOpacity } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+interface PresetOptionsModalProps {
+  visible: boolean;
+  onClose: () => void;
+  isDark: boolean;
+  presetName: string;
+  isBootPreset: boolean;
+  showDelete?: boolean;
+  onEnableAtBoot: () => void;
+  onDelete: () => void;
+}
+
+export default function PresetOptionsModal({
+  visible,
+  onClose,
+  isDark,
+  presetName,
+  isBootPreset,
+  showDelete = true,
+  onEnableAtBoot,
+  onDelete,
+}: PresetOptionsModalProps) {
+  const textColor = isDark ? '#ffffff' : '#111827';
+  const subtextColor = isDark ? '#9ca3af' : '#6b7280';
+  const backgroundColor = isDark ? '#1f2937' : '#ffffff';
+  const borderColor = isDark ? '#4b5563' : '#1e293b';
+
+  return (
+    <Modal
+      visible={visible}
+      transparent={true}
+      animationType="fade"
+      onRequestClose={onClose}
+    >
+      <TouchableOpacity
+        style={styles.dropdownOverlay}
+        activeOpacity={1}
+        onPress={onClose}
+      >
+        <TouchableOpacity
+          activeOpacity={1}
+          onPress={(e) => e.stopPropagation()}
+        >
+          <View style={[styles.dropdownModal, { backgroundColor, borderColor }]}>
+            {/* Title */}
+            <Text style={[styles.dropdownTitle, { color: textColor }]} numberOfLines={1}>
+              {presetName}
+            </Text>
+
+            {/* Enable at Boot Option */}
+            <TouchableOpacity
+              style={styles.optionButton}
+              onPress={() => {
+                onEnableAtBoot();
+                onClose();
+              }}
+            >
+              <Ionicons
+                name={isBootPreset ? "checkmark-circle" : "power"}
+                size={24}
+                color={isBootPreset ? "#10b981" : "#3b82f6"}
+              />
+              <View style={styles.optionInfo}>
+                <Text style={[styles.optionTitle, { color: textColor }]}>
+                  {isBootPreset ? "Enabled at Boot" : "Enable at Boot"}
+                </Text>
+                <Text style={[styles.optionDescription, { color: subtextColor }]}>
+                  {isBootPreset
+                    ? "Loads on device power-on"
+                    : "Activate when device powers on"
+                  }
+                </Text>
+              </View>
+              {isBootPreset && (
+                <Ionicons name="checkmark" size={20} color="#10b981" />
+              )}
+            </TouchableOpacity>
+
+            {/* Delete Preset Option */}
+            {showDelete && (
+              <TouchableOpacity
+                style={styles.optionButton}
+                onPress={() => {
+                  onDelete();
+                  onClose();
+                }}
+              >
+                <Ionicons name="trash-outline" size={24} color="#ef4444" />
+                <View style={styles.optionInfo}>
+                  <Text style={[styles.optionTitle, { color: '#ef4444' }]}>
+                    Delete Preset
+                  </Text>
+                  <Text style={[styles.optionDescription, { color: subtextColor }]}>
+                    Remove from WLED device
+                  </Text>
+                </View>
+              </TouchableOpacity>
+            )}
+          </View>
+        </TouchableOpacity>
+      </TouchableOpacity>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  dropdownOverlay: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    zIndex: 1000,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  dropdownModal: {
+    borderRadius: 12,
+    padding: 16,
+    borderWidth: 2,
+    minWidth: 320,
+    maxWidth: 400,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.25,
+    shadowRadius: 12,
+    elevation: 15,
+    zIndex: 1001,
+  },
+  dropdownTitle: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    marginBottom: 16,
+    textAlign: 'center',
+  },
+  optionButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 16,
+    paddingHorizontal: 12,
+    minHeight: 64,
+  },
+  optionInfo: {
+    flex: 1,
+    marginLeft: 12,
+  },
+  optionTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  optionDescription: {
+    fontSize: 12,
+    marginTop: 2,
+    fontWeight: '500',
+  },
+});

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -16,6 +16,7 @@ export const STORAGE_KEYS = {
   DEVICE_CONFIG: "kolori_device_config",
   SEASONAL_PRESETS: "kolori_seasonal_presets",
   DEVICE_SEASONAL_PRESETS: "kolori_device_seasonal_presets",
+  BOOT_PRESET_ID: "kolori_boot_preset_id",
 };
 
 class Storage {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.2.11

* **New Features**
  * Added boot preset management—select which preset plays at startup
  * Long-press presets to access options (enable at boot or delete)
  * Boot preset indicator displays on active startup preset
  * Device IP address now visible in device selector
  * Close button added to floating modal for easier dismissal

<!-- end of auto-generated comment: release notes by coderabbit.ai -->